### PR TITLE
Bug fix for API url, overall code uplift

### DIFF
--- a/pyfwc/__version__.py
+++ b/pyfwc/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 2, 2)
+VERSION = (0, 3, 0)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/pyfwc/fwc.py
+++ b/pyfwc/fwc.py
@@ -54,7 +54,7 @@ class FWCAPI():
                 self.baseurl = url
                 break
             else:
-                error_msg.append(f'Failed to access {url}, error message: {test_conn.json()['errors'][0]['detail']}')
+                error_msg.append(f'Failed to access {url}, error message: {test_conn.json()["errors"][0]["detail"]}')
         if self.baseurl is None:
             raise ValueError('\n'.join(error_msg))
             

--- a/pyfwc/fwc.py
+++ b/pyfwc/fwc.py
@@ -44,7 +44,19 @@ class FWCAPI():
         'Cache-Control': 'no-cache',
         'Ocp-Apim-Subscription-Key': self.key,
         }
-        self.baseurl = "https://api.fwc.gov.au/api/v1/awards"
+        url_list = ['https://api.fwc.gov.au/api/v1/awards', 'https://uatapi.fwc.gov.au/api/v1/awards']
+        self.baseurl = None
+        error_msg = []
+        for url in url_list:
+            test_conn = requests.get(url, headers=self.hdr)
+            if test_conn.status_code == 200:
+                self.baseurl = url
+                break
+            else:
+                error_msg.append(f'Failed to access {url}, error message: {test_conn.json()['errors'][0]['detail']}')
+        if self.baseurl == None:
+            raise ValueError('\n'.join(error_msg))
+            
 
     def get_awards(self,name,award_operative_from=None,award_operative_to=None):
         """This API is designed to retrieve a list of modern awards to support payroll business processes. https://uatdeveloper.fwc.gov.au/api-details#api=fwc-maapi-v1&operation=GetAwards

--- a/pyfwc/fwc.py
+++ b/pyfwc/fwc.py
@@ -5,44 +5,45 @@ import time
 class FWCAPI():
 
     @staticmethod
-    def __get_results(query_url,hdr,payload):
-        response = requests.get(url=query_url,headers=hdr,params=payload)
+    def __get_results(query_url: str, hdr: dict, payload: dict) -> pd.DataFrame: 
+        response = requests.get(url=query_url, headers=hdr, params=payload)
         response_json = response.json()        
         if response.status_code != 200:
             raise ValueError(response_json['errors'][0]['detail'])
         
         if 'page_count' not in response_json['_meta']:
-            result_df=pd.DataFrame.from_records([response_json['result']])
+            result_df = pd.DataFrame.from_records([response_json['result']])
         else:
             page_count = response_json['_meta']['page_count']
             result_list=[]
             result_list.append(pd.DataFrame.from_dict(response_json['results']))
 
             # if # of page >=2, get all pages results
-            if(page_count>1):
-                for idx in range(2,page_count+1):
+            if page_count > 1:
+                for idx in range(2, page_count + 1):
                     page_paras = {
                         'page' : idx,
                         'limit': 100
-                            }
-                    page_response = requests.get(url=query_url,headers=hdr,params=page_paras).json()
+                    }
+                    page_response = requests.get(url=query_url, headers=hdr, params=page_paras).json()
                     result_list.append(pd.DataFrame.from_dict(page_response['results']))
                     time.sleep(1)
             result_df = pd.concat(result_list)            
         return result_df
 
-    def __init__(self,subscription_key):
+    def __init__(self, subscription_key: str):
         """A wrapper for Australian Fair Work Commission Modern Awards API https://uatdeveloper.fwc.gov.au/
 
         Parameters
         ----------
         subscription_key : string 
-            The subscription key used for the API access. You should be able to find it under "Profile" section once you have registered.
+            The subscription key used for the API access. You should be able to find it under "Profile" section once
+            you have registered.
         """
         self.key = subscription_key
         self.hdr = {
-        'Cache-Control': 'no-cache',
-        'Ocp-Apim-Subscription-Key': self.key,
+            'Cache-Control': 'no-cache',
+            'Ocp-Apim-Subscription-Key': self.key,
         }
         url_list = ['https://api.fwc.gov.au/api/v1/awards', 'https://uatapi.fwc.gov.au/api/v1/awards']
         self.baseurl = None
@@ -54,21 +55,27 @@ class FWCAPI():
                 break
             else:
                 error_msg.append(f'Failed to access {url}, error message: {test_conn.json()['errors'][0]['detail']}')
-        if self.baseurl == None:
+        if self.baseurl is None:
             raise ValueError('\n'.join(error_msg))
             
 
-    def get_awards(self,name,award_operative_from=None,award_operative_to=None):
-        """This API is designed to retrieve a list of modern awards to support payroll business processes. https://uatdeveloper.fwc.gov.au/api-details#api=fwc-maapi-v1&operation=GetAwards
+    def get_awards(self, name: str, award_operative_from: str = None, award_operative_to: str = None) -> pd.DataFrame:
+        """This API is designed to retrieve a list of modern awards to support payroll business processes.
+        https://uatdeveloper.fwc.gov.au/api-details#api=fwc-maapi-v1&operation=GetAwards
 
         Parameters
         ----------
         name : string
-            The human readable title of the award. Example:"mining" returns all awards with the word 'mining' in its title. You can use the plus sign ("+") to add multiple keywords to refine your search. "Mining+Black" will return awards which have the word "mining" AND "black".
+            The human readable title of the award.
+            Example: "mining" returns all awards with the word 'mining' in its title.
+            You can use the plus sign ("+") to add multiple keywords to refine your search.
+            "Mining+Black" will return awards which have the word "mining" AND "black".
         award_operative_from : string, optional
-            Format - date-time (as date-time in RFC3339). The date when the award came into operation. The default format is "YYYY-MM-DD", by default None
+            Format - date-time (as date-time in RFC3339). The date when the award came into operation.
+            The default format is "YYYY-MM-DD", by default None
         award_operative_to : _type_, optional
-            Format - date-time (as date-time in RFC3339). The date when the award ceased to be in effect (was revoked). The default format is "YYYY-MM-DD", by default None
+            Format - date-time (as date-time in RFC3339). The date when the award ceased to be in effect (was revoked).
+            The default format is "YYYY-MM-DD", by default None
 
         Returns
         -------
@@ -78,26 +85,31 @@ class FWCAPI():
         # construct url
         query_url = f"{self.baseurl}?"
 
-        #construct payload to API
-        payload = {}
-        payload['name'] = name
-        payload['award_operative_from']=award_operative_from
-        payload['award_operative_to']=award_operative_to
-        payload['limit']=100
+        # construct payload to API
+        payload = {
+            'name': name,
+            'award_operative_from': award_operative_from,
+            'award_operative_to': award_operative_to,
+            'limit': 100
+        }
 
-        return self.__get_results(query_url,self.hdr,payload)
+        return self.__get_results(query_url, self.hdr, payload)
 
-    def get_award(self,id_or_code,award_operative_from=None,award_operative_to=None):
-        """This API is designed to retrieve a modern award using the "award_fixed_id" or the award "code" to support payroll business processes. https://uatdeveloper.fwc.gov.au/api-details#api=fwc-maapi-v1&operation=AwardsIdentification
+    def get_award(self, id_or_code: str, award_operative_from:str = None, award_operative_to:str = None) -> pd.DataFrame:
+        """This API is designed to retrieve a modern award using the "award_fixed_id" or the award "code" to support
+        payroll business processes.
+        https://uatdeveloper.fwc.gov.au/api-details#api=fwc-maapi-v1&operation=AwardsIdentification
 
         Parameters
         ----------
         id_or_code : string
             Search by "award_fixed_id" or "code". Example "id_or_code="12" or "id_or_code"="MA000012".
         award_operative_from : string, optional
-            Format - date-time (as date-time in RFC3339). The date when the award came into operation. The default format is "YYYY-MM-DD", by default None
+            Format - date-time (as date-time in RFC3339). The date when the award came into operation.
+            The default format is "YYYY-MM-DD", by default None
         award_operative_to : _type_, optional
-            Format - date-time (as date-time in RFC3339). The date when the award ceased to be in effect (was revoked). The default format is "YYYY-MM-DD", by default None
+            Format - date-time (as date-time in RFC3339). The date when the award ceased to be in effect (was revoked).
+            The default format is "YYYY-MM-DD", by default None
 
         Returns
         -------
@@ -108,23 +120,28 @@ class FWCAPI():
         # construct url
         query_url = f"{self.baseurl}/{id_or_code}"
 
-        #construct payload to API
-        payload = {}
-        payload['award_operative_from']=award_operative_from
-        payload['award_operative_to']=award_operative_to
-        payload['limit']=100
+        # construct payload to API
+        payload = {
+            'award_operative_from': award_operative_from,
+            'award_operative_to': award_operative_to,
+            'limit': 100
+        }
 
-        return self.__get_results(query_url,self.hdr,payload)        
+        return self.__get_results(query_url, self.hdr, payload)        
 
-    def get_classification(self,id_or_code,classification_fixed_id):
-        """This API is designed to retrieve a current individual classification for a specific award using a fixed identifier. https://uatdeveloper.fwc.gov.au/api-details#api=fwc-maapi-v1&operation=IndividualClassification
+    def get_classification(self, id_or_code: str, classification_fixed_id: str) -> pd.DataFrame:
+        """This API is designed to retrieve a current individual classification for a specific award using a
+        fixed identifier.
+        https://uatdeveloper.fwc.gov.au/api-details#api=fwc-maapi-v1&operation=IndividualClassification
 
         Parameters
         ----------
         id_or_code : string
-            Search by "award_fixed_id" or "code". Example "id_or_code="12" or "id_or_code"="MA000012".
+            Search by "award_fixed_id" or "code".
+            Example "id_or_code="12" or "id_or_code"="MA000012".
         classification_fixed_id : string
-            Format - int32. Unique identification number of classification that is fixed over each year. Example: "classification_fixed_id"="98".
+            Format - int32. Unique identification number of classification that is fixed over each year.
+            Example: "classification_fixed_id"="98".
 
         Returns
         -------
@@ -135,29 +152,42 @@ class FWCAPI():
         # construct url
         query_url = f"{self.baseurl}/{id_or_code}/classifications/{classification_fixed_id}"
 
-        #construct payload to API
-        payload = {}
-        payload['limit']=100
+        # construct payload to API
+        payload = {
+            'limit': 100
+        }
 
-        return self.__get_results(query_url,self.hdr,payload)   
+        return self.__get_results(query_url, self.hdr, payload)   
 
-    def get_payrates(self,id_or_code,classification_level=None,classification_fixed_id=None,employee_rate_type_code=None,operative_from=None,operative_to=None):
-        """This API is designed to retrieve the pay-rates for a given award to support payroll business processes. https://uatdeveloper.fwc.gov.au/api-details#api=fwc-maapi-v1&operation=GetPayRates
+    def get_payrates(self, id_or_code: str, classification_level: str = None, classification_fixed_id: int = None,
+                     employee_rate_type_code: str = None, operative_from: str = None,
+                     operative_to: str = None) -> pd.DataFrame:
+        """This API is designed to retrieve the pay-rates for a given award to support payroll business processes.
+        https://uatdeveloper.fwc.gov.au/api-details#api=fwc-maapi-v1&operation=GetPayRates
 
         Parameters
         ----------
         id_or_code : string
-            Search by "award_fixed_id" or "code". Example "id_or_code="12" or "id_or_code"="MA000012".
+            Search by "award_fixed_id" or "code".
+            Example "id_or_code="12" or "id_or_code"="MA000012".
         classification_level : string, optional
-            Format - int32. A numerical representation of the classification within the hierarchical structure of classifications in a clause. Starts at 1 for the lowest level classification. Example: "classification_level"="1", by default None
+            Format - int32. A numerical representation of the classification within the hierarchical structure of
+            classifications in a clause. Starts at 1 for the lowest level classification.
+            Example: "classification_level"="1", by default None
         classification_fixed_id : string, optional
-            Format - int32. Unique identification number of classification that is fixed over each year. Example "classification_fixed_id"="549", by default None
+            Format - int32. Unique identification number of classification that is fixed over each year.
+            Example "classification_fixed_id"="549", by default None
         employee_rate_type_code : string, optional
-            An indicator if the rate is for an adult or otherwise. Go to Documentation Guide, Classification tab for the categories. Search with a comma (",") delimiter to allow multiple codes. Example: "employee_rate_type_code"="AD" or "employee_rate_type_code"="AD,TN", by default None
+            An indicator if the rate is for an adult or otherwise.
+            Go to Documentation Guide, Classification tab for the categories.
+            Search with a comma (",") delimiter to allow multiple codes.
+            Example: "employee_rate_type_code"="AD" or "employee_rate_type_code"="AD,TN", by default None
         operative_from : string, optional
-            Format - date-time (as date-time in RFC3339). The date on which the classification came into effect. The default format is "YYYY-MM-DD", by default None
+            Format - date-time (as date-time in RFC3339). The date on which the classification came into effect.
+            The default format is "YYYY-MM-DD", by default None
         operative_to : string, optional
-            Format - date-time (as date-time in RFC3339). The date on which the classification ceased to be in effect. The default format is "YYYY-MM-DD", by default None
+            Format - date-time (as date-time in RFC3339). The date on which the classification ceased to be in effect.
+            The default format is "YYYY-MM-DD", by default None
 
         Returns
         -------
@@ -168,32 +198,42 @@ class FWCAPI():
         # construct url
         query_url = f"{self.baseurl}/{id_or_code}/pay-rates?"
 
-        #construct payload to API
-        payload = {}
-        payload['classification_level']=classification_level
-        payload['classification_fixed_id']=classification_fixed_id
-        payload['employee_rate_type_code']=employee_rate_type_code
-        payload['operative_from']=operative_from
-        payload['operative_to']=operative_to
-        payload['limit']=100
+        # construct payload to API
+        payload = {
+            'classification_level': classification_level,
+            'classification_fixed_id': classification_fixed_id,
+            'employee_rate_type_code': employee_rate_type_code,
+            'operative_from': operative_from,
+            'operative_to': operative_to,
+            'limit': 100
+        }
 
-        return self.__get_results(query_url,self.hdr,payload)       
+        return self.__get_results(query_url, self.hdr, payload)       
 
-    def get_classifications(self,id_or_code,classification_level=None,classification_fixed_id=None,operative_from=None,operative_to=None):
-        """This API is designed to retrieve award classification information using the "award_ fixed_ id" or the award "code" to support payroll business processes. https://uatdeveloper.fwc.gov.au/api-details#api=fwc-maapi-v1&operation=AwardClassification
+    def get_classifications(self, id_or_code: str, classification_level: str = None, classification_fixed_id: int = None,
+                            operative_from: str = None, operative_to: str = None) -> pd.DataFrame:
+        """This API is designed to retrieve award classification information using the "award_ fixed_ id" or the award
+        "code" to support payroll business processes.
+        https://uatdeveloper.fwc.gov.au/api-details#api=fwc-maapi-v1&operation=AwardClassification
 
         Parameters
         ----------
         id_or_code : string
-            Search by "award_fixed_id" or "code". Example "id_or_code="12" or "id_or_code"="MA000012".
+            Search by "award_fixed_id" or "code".
+            Example "id_or_code="12" or "id_or_code"="MA000012".
         classification_level : string, optional
-            Format - int32. A numerical representation of the classification within the hierarchical structure of classifications in a clause. Starts at 1 for the lowest level classification. Example: "classification_level"="1", by default None
+            Format - int32. A numerical representation of the classification within the hierarchical structure of
+            classifications in a clause. Starts at 1 for the lowest level classification.
+            Example: "classification_level"="1", by default None
         classification_fixed_id : string, optional
-            Format - int32. Unique identification number of classification that is fixed over each year. Example "classification_fixed_id"="549", by default None
+            Format - int32. Unique identification number of classification that is fixed over each year.
+            Example "classification_fixed_id"="549", by default None
         operative_from : string, optional
-            Format - date-time (as date-time in RFC3339). The date on which the classification came into effect. The default format is "YYYY-MM-DD", by default None
+            Format - date-time (as date-time in RFC3339). The date on which the classification came into effect.
+            The default format is "YYYY-MM-DD", by default None
         operative_to : string, optional
-            Format - date-time (as date-time in RFC3339). The date on which the classification ceased to be in effect. The default format is "YYYY-MM-DD", by default None
+            Format - date-time (as date-time in RFC3339). The date on which the classification ceased to be in effect.
+            The default format is "YYYY-MM-DD", by default None
 
         Returns
         -------
@@ -204,28 +244,35 @@ class FWCAPI():
         # construct url
         query_url = f"{self.baseurl}/{id_or_code}/classifications?"
 
-        #construct payload to API
-        payload = {}
-        payload['classification_level']=classification_level
-        payload['classification_fixed_id']=classification_fixed_id
-        payload['operative_from']=operative_from
-        payload['operative_to']=operative_to        
-        payload['limit']=100
+        # construct payload to API
+        payload = {
+            'classification_level': classification_level,
+            'classification_fixed_id': classification_fixed_id,
+            'operative_from': operative_from,
+            'operative_to': operative_to,
+            'limit': 100
+        }
         
-        return self.__get_results(query_url,self.hdr,payload)    
+        return self.__get_results(query_url, self.hdr, payload)    
 
 
         
 
-    def get_current_payrate(self,id_or_code,classification_fixed_id):
-        """This API is designed to retrieve the current pay-rate of an individual classification for a specific award using a fixed identifier. Where the query returns more than one result, the default sort is "calculated_pay_rate_id" ascending and then "calculated_rate_type" ascending. https://uatdeveloper.fwc.gov.au/api-details#api=fwc-maapi-v1&operation=IndividualPayRate
+    def get_current_payrate(self, id_or_code: str, classification_fixed_id: int) -> pd.DataFrame:
+        """This API is designed to retrieve the current pay-rate of an individual classification for a specific award
+        using a fixed identifier.
+        Where the query returns more than one result, the default sort is "calculated_pay_rate_id" ascending and then
+        "calculated_rate_type" ascending.
+        https://uatdeveloper.fwc.gov.au/api-details#api=fwc-maapi-v1&operation=IndividualPayRate
 
         Parameters
         ----------
         id_or_code : string
-            Search by "award_fixed_id" or "code". Example "id_or_code="12" or "id_or_code"="MA000012".
+            Search by "award_fixed_id" or "code".
+            Example "id_or_code="12" or "id_or_code"="MA000012".
         classification_fixed_id : string
-            Format - int32. Unique identification number of classification that is fixed over each year. Example "classification_fixed_id"="549".
+            Format - int32. Unique identification number of classification that is fixed over each year.
+            Example "classification_fixed_id"="549".
 
         Returns
         -------
@@ -236,21 +283,26 @@ class FWCAPI():
         # construct url
         query_url = f"{self.baseurl}/{id_or_code}/classifications/{classification_fixed_id}/pay-rates?"
 
-        #construct payload to API
-        payload = {}
-        payload['limit']=100
+        # construct payload to API
+        payload = {
+            'limit': 100
+        }
 
-        return self.__get_results(query_url,self.hdr,payload)
+        return self.__get_results(query_url, self.hdr, payload)
 
-    def get_expense_allowance(self,id_or_code,expense_allowance_fixed_id):
-        """This API is designed to retrieve a current individual expense-related allowance for a specific award using a fixed identifier. https://uatdeveloper.fwc.gov.au/api-details#api=fwc-maapi-v1&operation=IndividualExpenseAllowance
+    def get_expense_allowance(self, id_or_code: str, expense_allowance_fixed_id: int) -> pd.DataFrame:
+        """This API is designed to retrieve a current individual expense-related allowance for a specific award using a
+        fixed identifier.
+        https://uatdeveloper.fwc.gov.au/api-details#api=fwc-maapi-v1&operation=IndividualExpenseAllowance
 
         Parameters
         ----------
         id_or_code : string
-            Search by "award_fixed_id" or "code". Example "id_or_code="12" or "id_or_code"="MA000012".
+            Search by "award_fixed_id" or "code".
+            Example "id_or_code="12" or "id_or_code"="MA000012".
         expense_allowance_fixed_id : string
-            Format - int32. Unique identification number of the expense-related allowance that is fixed over each year. Example "expense_allowance_fixed_id"="9"
+            Format - int32. Unique identification number of the expense-related allowance that is fixed over each year.
+            Example "expense_allowance_fixed_id"="9"
 
         Returns
         -------
@@ -261,27 +313,39 @@ class FWCAPI():
         # construct url
         query_url = f"{self.baseurl}/{id_or_code}/expense-allowances/{expense_allowance_fixed_id}"
 
-        #construct payload to API
-        payload = {}
-        payload['limit']=100
+        # construct payload to API
+        payload = {
+            'limit': 100
+        }
 
-        return self.__get_results(query_url,self.hdr,payload)        
+        return self.__get_results(query_url, self.hdr, payload)        
 
-    def get_expense_allowances(self,id_or_code,allowance_type_code=None,is_all_purpose=None,operative_from=None,operative_to=None):
-        """This API is designed to retrieve the expense-related allowance for a specific award using the "award_fixed_id" or the award "code" to support payroll business processes. https://uatdeveloper.fwc.gov.au/api-details#api=fwc-maapi-v1&operation=ExpenseAllowances
+    def get_expense_allowances(self, id_or_code: str, allowance_type_code: str = None, is_all_purpose:str = None,
+                               operative_from: str = None,operative_to: str = None) -> pd.DataFrame:
+        """This API is designed to retrieve the expense-related allowance for a specific award using the "award_fixed_id"
+        or the award "code" to support payroll business processes.
+        https://uatdeveloper.fwc.gov.au/api-details#api=fwc-maapi-v1&operation=ExpenseAllowances
 
         Parameters
         ----------
         id_or_code : string
-            Search by "award_fixed_id" or "code". Example "id_or_code="12" or "id_or_code"="MA000012".
+            Search by "award_fixed_id" or "code".
+            Example "id_or_code="12" or "id_or_code"="MA000012".
         allowance_type_code : string, optional
-            Codes used by the ATO for single touch pay roll. Go to the Documentation Guide, Allowance Codes tab for a full list of codes. Search with a comma (",") delimiter to allow multiple codes. Example: "allowance_type_code"="MD" or "allowance_type_code"="MD,CD", by default None
+            Codes used by the ATO for single touch pay roll.
+            Go to the Documentation Guide, Allowance Codes tab for a full list of codes.
+            Search with a comma (",") delimiter to allow multiple codes.
+            Example: "allowance_type_code"="MD" or "allowance_type_code"="MD,CD", by default None
         is_all_purpose : string, optional
-            Used to flag whether an allowance applies for all purposes. The default value is null ("--"). Example: "true" or "false", by default None
+            Used to flag whether an allowance applies for all purposes.
+            The default value is null ("--").
+            Example: "true" or "false", by default None
         operative_from : string, optional
-            Format - date-time (as date-time in RFC3339). The date on which the allowance came into effect. The default format is "YYYY-MM-DD", by default None
+            Format - date-time (as date-time in RFC3339). The date on which the allowance came into effect.
+            The default format is "YYYY-MM-DD", by default None
         operative_to : string, optional
-            Format - date-time (as date-time in RFC3339). The date on which the allowance ceased to be in effect. The default format is "YYYY-MM-DD"., by default None
+            Format - date-time (as date-time in RFC3339). The date on which the allowance ceased to be in effect.
+            The default format is "YYYY-MM-DD"., by default None
 
         Returns
         -------
@@ -292,38 +356,55 @@ class FWCAPI():
         # construct url
         query_url = f"{self.baseurl}/{id_or_code}/expense-allowances?"
 
-        #construct payload to API
-        payload = {}
-        payload['allowance_type_code']=allowance_type_code
-        payload['is_all_purpose']=is_all_purpose
-        payload['operative_from']=operative_from
-        payload['operative_to']=operative_to
-        payload['limit']=100
+        # construct payload to API
+        payload = {
+            'allowance_type_code': allowance_type_code,
+            'is_all_purpose': is_all_purpose,
+            'operative_from': operative_from,
+            'operative_to': operative_to,
+            'limit': 100
+        }
 
-        return self.__get_results(query_url,self.hdr,payload)        
+        return self.__get_results(query_url, self.hdr, payload)        
 
 
-    def get_penalties(self,id_or_code,penalty_fixed_id=None,classification_level=None,penalty_code=None,employee_rate_type_code=None,base_pay_rate_Id=None,operative_from=None,operative_to=None):
-        """This API is designed to retrieve the penalties for a given award using the "award_fixed_id" or award "code" to support payroll business processes. https://uatdeveloper.fwc.gov.au/api-details#api=fwc-maapi-v1&operation=PenaltyModel
+    def get_penalties(self, id_or_code: str, penalty_fixed_id:str = None, classification_level: str = None,
+                      penalty_code: str = None, employee_rate_type_code: str = None, base_pay_rate_Id: str = None,
+                      operative_from: str = None, operative_to: str = None) -> pd.DataFrame:
+        """This API is designed to retrieve the penalties for a given award using the "award_fixed_id" or award "code"
+        to support payroll business processes
+        https://uatdeveloper.fwc.gov.au/api-details#api=fwc-maapi-v1&operation=PenaltyModel
 
         Parameters
         ----------
         id_or_code : string
-            Search by "award_fixed_id" or "code". Example "id_or_code="12" or "id_or_code"="MA000012".
+            Search by "award_fixed_id" or "code".
+            Example "id_or_code="12" or "id_or_code"="MA000012".
         penalty_fixed_id : string, optional
             Format - int32. Unique identification number of the penalty that is fixed over time, by default None
         classification_level : string, optional
-            Format - int32. A numerical representation of the classification within the hierarchical structure of classifications in a clause. Starts at 1 for the lowest level classification. Example: "classification_level"="1", by default None
+            Format - int32. A numerical representation of the classification within the hierarchical structure of
+            classifications in a clause. Starts at 1 for the lowest level classification.
+            Example: "classification_level"="1", by default None
         penalty_code : string, optional
-            A 5-digit code used to categorize a penalty rate. Go to the Documentation Guide, Penalty Codes tab for a full list of codes. Search with a comma (",") delimiter to allow multiple codes. Example "penalty_code"="OTFMF" or "penalty_code"="OTFMF,SWTMO", by default None
+            A 5-digit code used to categorize a penalty rate.
+            Go to the Documentation Guide, Penalty Codes tab for afull list of codes.
+            Search with a comma (",") delimiter to allow multiple codes.
+            Example "penalty_code"="OTFMF" or "penalty_code"="OTFMF,SWTMO", by default None
         employee_rate_type_code : string, optional
-            An indicator if the rate is for an adult or otherwise. Go to Documentation Guide, Penalty tab for the categories. Search with a comma (",") delimiter to allow multiple codes. Example: "employee_rate_type_code"="AD" or "employee_rate_type_code"="AD,TN", by default None
+            An indicator if the rate is for an adult or otherwise.
+            Go to Documentation Guide, Penalty tab for the categories.
+            Search with a comma (",") delimiter to allow multiple codes.
+            Example: "employee_rate_type_code"="AD" or "employee_rate_type_code"="AD,TN", by default None
         base_pay_rate_Id : string, optional
-            A unique identification number of the base pay-rate resource used to calculate the penalty value. Example "basePayRateId=123456", by default None
+            A unique identification number of the base pay-rate resource used to calculate the penalty value.
+            Example "basePayRateId=123456", by default None
         operative_from : string, optional
-            Format - date-time (as date-time in RFC3339). The date on which the classification came into effect. The default format is "YYYY-MM-DD", by default None
+            Format - date-time (as date-time in RFC3339). The date on which the classification came into effect.
+            The default format is "YYYY-MM-DD", by default None
         operative_to : string, optional
-            Format - date-time (as date-time in RFC3339). The date on which the classification ceased to be in effect. The default format is "YYYY-MM-DD", by default None
+            Format - date-time (as date-time in RFC3339). The date on which the classification ceased to be in effect.
+            The default format is "YYYY-MM-DD", by default None
 
         Returns
         -------
@@ -334,28 +415,32 @@ class FWCAPI():
         # construct url
         query_url = f"{self.baseurl}/{id_or_code}/penalties?"
 
-        #construct payload to API
-        payload = {}
-        payload['penalty_fixed_id']=penalty_fixed_id
-        payload['classification_level']=classification_level
-        payload['penalty_code']=penalty_code
-        payload['employee_rate_type_code']=employee_rate_type_code
-        payload['base_pay_rate_Id']=base_pay_rate_Id
-        payload['operative_from']=operative_from
-        payload['operative_to']=operative_to
-        payload['limit']=100
+        # construct payload to API
+        payload = {
+            'penalty_fixed_id': penalty_fixed_id,
+            'classification_level': classification_level,
+            'penalty_code': penalty_code,
+            'employee_rate_type_code': employee_rate_type_code,
+            'base_pay_rate_Id': base_pay_rate_Id,
+            'operative_from': operative_from,
+            'operative_to': operative_to,
+            'limit': 100
+        }
 
-        return self.__get_results(query_url,self.hdr,payload)        
+        return self.__get_results(query_url, self.hdr, payload)        
 
-    def get_wage_allowance(self,id_or_code,wage_allowance_fixed_id):
-        """This API is designed to retrieve a current individual wage-related allowance for a specific award using a fixed identifier. https://uatdeveloper.fwc.gov.au/api-details#api=fwc-maapi-v1&operation=IndividualWageAllowance
+    def get_wage_allowance(self, id_or_code: str, wage_allowance_fixed_id: str) -> pd.DataFrame:
+        """This API is designed to retrieve a current individual wage-related allowance for a specific award using a
+        fixed identifier.
+        https://uatdeveloper.fwc.gov.au/api-details#api=fwc-maapi-v1&operation=IndividualWageAllowance
 
         Parameters
         ----------
         id_or_code : string
             Search by "award_fixed_id" or "code". Example "id_or_code="12" or "id_or_code"="MA000012".
         wage_allowance_fixed_id : string
-            Format - int32. Unique identification number of the wage-related allowance that is fixed over each year. Example: "wage_allowance_fixed_id"="191"
+            Format - int32. Unique identification number of the wage-related allowance that is fixed over each year.
+            Example: "wage_allowance_fixed_id"="191"
 
         Returns
         -------
@@ -366,27 +451,39 @@ class FWCAPI():
         # construct url
         query_url = f"{self.baseurl}/{id_or_code}/wage-allowances/{wage_allowance_fixed_id}"
 
-        #construct payload to API
-        payload = {}
-        payload['limit']=100
+        # construct payload to API
+        payload = {
+            'limit': 100
+        }
 
-        return self.__get_results(query_url,self.hdr,payload)        
 
-    def get_wage_allowances(self,id_or_code,allowance_type_code=None,is_all_purpose=None,operative_from=None,operative_to=None):
-        """This API is designed to retrieve the wage-related allowance for a specific award using the "award_fixed_id" or the award "code" to support payroll business processes. https://uatdeveloper.fwc.gov.au/api-details#api=fwc-maapi-v1&operation=WageAllowanceModel
+        return self.__get_results(query_url, self.hdr, payload)        
+
+    def get_wage_allowances(self, id_or_code: str, allowance_type_code: str = None, is_all_purpose:str = None,
+                            operative_from: str = None, operative_to: str = None) -> pd.DataFrame:
+        """This API is designed to retrieve the wage-related allowance for a specific award using the "award_fixed_id"
+        or the award "code" to support payroll business processes.
+        https://uatdeveloper.fwc.gov.au/api-details#api=fwc-maapi-v1&operation=WageAllowanceModel
 
         Parameters
         ----------
         id_or_code : string
-            Search by "award_fixed_id" or "code". Example "id_or_code="12" or "id_or_code"="MA000012".
+            Search by "award_fixed_id" or "code".
+            Example "id_or_code="12" or "id_or_code"="MA000012".
         allowance_type_code : string, optional
-            Codes used by the ATO for single touch pay roll. Go to the Documentation Guide, Allowance Codes tab for a full list of codes. Search with a comma (",") delimiter to allow multiple codes. Example: "allowance_type_code"="MD" or "allowance_type_code"="MD,CD", by default None
+            Codes used by the ATO for single touch pay roll.
+            Go to the Documentation Guide, Allowance Codes tab for a full list of codes.
+            Search with a comma (",") delimiter to allow multiple codes.
+            Example: "allowance_type_code"="MD" or "allowance_type_code"="MD,CD", by default None
         is_all_purpose : string, optional
-            Used to flag whether an allowance applies for all purposes. The default value is null ("--"). Example: "true" or "false", by default None
+            Used to flag whether an allowance applies for all purposes.
+            The default value is null ("--"). Example: "true" or "false", by default None
         operative_from : string, optional
-            Format - date-time (as date-time in RFC3339). The date on which the allowance came into effect. The default format is "YYYY-MM-DD", by default None
+            Format - date-time (as date-time in RFC3339). The date on which the allowance came into effect.
+            The default format is "YYYY-MM-DD", by default None
         operative_to : string, optional
-            Format - date-time (as date-time in RFC3339). The date on which the allowance ceased to be in effect. The default format is "YYYY-MM-DD"., by default None
+            Format - date-time (as date-time in RFC3339). The date on which the allowance ceased to be in effect.
+            The default format is "YYYY-MM-DD"., by default None
 
         Returns
         -------
@@ -397,12 +494,14 @@ class FWCAPI():
         # construct url
         query_url = f"{self.baseurl}/{id_or_code}//wage-allowances?"
 
-        #construct payload to API
-        payload = {}
-        payload['allowance_type_code']=allowance_type_code
-        payload['is_all_purpose']=is_all_purpose
-        payload['operative_from']=operative_from
-        payload['operative_to']=operative_to
-        payload['limit']=100
+        # construct payload to API
+        payload = {
+            'allowance_type_code': allowance_type_code,
+            'is_all_purpose': is_all_purpose,
+            'operative_from': operative_from,
+            'operative_to': operative_to,
+            'limit': 100
+        }
 
-        return self.__get_results(query_url,self.hdr,payload)    
+        return self.__get_results(query_url, self.hdr, payload)    
+    

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ URL = 'https://github.com/frankzhangsyd/pyfwc'
 EMAIL = 'frank.dingrui@gmail.com'
 AUTHOR = 'Frank Zhang'
 REQUIRES_PYTHON = '>=3.7.4'
-VERSION = '0.2.2'
+VERSION = '0.3.0'
 
 # What packages are required for this module to be executed?
 REQUIRED = [


### PR DESCRIPTION
FWC API frequenty changes between two URLs - **https://api.fwc.gov.au/api/v1/awards** or **https://uatapi.fwc.gov.au/api/v1/awards**

In commit 8a04b6d0bcee03251ea52689799eeface26f4560, URL was switched back to **https://api.fwc.gov.au/api/v1/awards** which stopped working again recently, therefore prompting this bug fix.

Commits for this pull request:
25e3dfbbf7388ff6c96486828c4add1afb1a609f - implemented connection checks for both URLs during init to determine which one is currently enabled by FWC
e780cc7c41167572411e0546044ddc8f9d18a355 - cleaned up formatting by adding spacing, updating docstrings, adding type hint to methods, and following 120 line length limit. Also uplifted payload dictionary declaration under each API method.

I've incremented the version from 0.2.2 to 0.3.0.

-edit to trigger github actions
